### PR TITLE
Allow optional columns in Maccor loader

### DIFF
--- a/beep/conversion_schemas/maccor_conversion.yaml
+++ b/beep/conversion_schemas/maccor_conversion.yaml
@@ -11,19 +11,19 @@ metadata_fields:
   procedure: protocol
   comment/barcode: barcode
 data_columns:
-  rec#: data_point
-  cyc#: cycle_index
-  step: step_index
-  test (sec): test_time
-  step (sec): step_time
+  rec#: data_point # REQUIRED
+  cyc#: cycle_index # REQUIRED
+  step: step_index # REQUIRED
+  test (sec): test_time # REQUIRED
+  step (sec): step_time # REQUIRED
   # amp-hr and watt-hr are a bit ambiguous
-  amp-hr: _capacity
-  watt-hr: _energy
-  amps: current
-  volts: voltage
-  state: _state
-  es: _ending_status
-  dpt time: date_time
+  amp-hr: _capacity # REQUIRED
+  watt-hr: _energy # REQUIRED
+  amps: current # REQUIRED
+  volts: voltage # REQUIRED
+  state: _state # REQUIRED
+  es: _ending_status # REQUIRED
+  dpt time: date_time # REQUIRED
   acimp/ohms: ac_impedence
   dcir/ohms: internal_resistance
   wf chg cap: _wf_chg_cap #charge_capacity

--- a/beep/structure/maccor.py
+++ b/beep/structure/maccor.py
@@ -14,6 +14,20 @@ from beep.conversion_schemas import MACCOR_CONFIG
 from beep.structure.base_eis import BEEPDatapathWithEIS, EIS
 from beep.structure.validate import PROJECT_SCHEMA
 
+REQUIRED_COLUMNS = [
+    "rec#",
+    "cyc#",
+    "step",
+    "test (sec)",
+    "step (sec)",
+    "amp-hr",
+    "watt-hr",
+    "amps",
+    "volts",
+    "state",
+    "es",
+    "dpt time",
+]
 
 class MaccorDatapath(BEEPDatapathWithEIS):
     """Datapath for ingesting and structuring Maccor battery cycler data.
@@ -84,8 +98,28 @@ class MaccorDatapath(BEEPDatapathWithEIS):
         # Parse data
         data = pd.read_csv(path, delimiter="\t", skiprows=1)
         data.rename(str.lower, axis="columns", inplace=True)
-        data = data.astype(MACCOR_CONFIG["data_types"])
-        data.rename(MACCOR_CONFIG["data_columns"], axis="columns", inplace=True)
+
+        expected = {c.lower() for c in MACCOR_CONFIG["data_columns"].keys()}
+        missing_cols = sorted(list(expected - set(data.columns)))
+        if missing_cols:
+            print(f"Missing columns: {missing_cols}")
+            for c in missing_cols:
+                data[c] = np.nan
+
+        missing_required = [c for c in REQUIRED_COLUMNS if c not in data.columns]
+        if missing_required:
+            raise KeyError(f"Missing required columns: {missing_required}")
+
+        for col, dtype in MACCOR_CONFIG["data_types"].items():
+            col_l = col.lower()
+            if col_l in data.columns:
+                data[col_l] = data[col_l].astype(dtype)
+
+        data.rename(
+            {k.lower(): v for k, v in MACCOR_CONFIG["data_columns"].items()},
+            axis="columns",
+            inplace=True,
+        )
 
         # Needed for validating correctly
         data["_state"] = data["_state"].astype(str)


### PR DESCRIPTION
## Summary
- allow loading Maccor files even if some optional columns are missing
- mark required columns in `maccor_conversion.yaml`

## Testing
- `pytest -k maccor -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_688ce0ef331c832d827500afcae96e52